### PR TITLE
Clarify trading cost handling in PnL criterion docs

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
@@ -31,7 +31,11 @@ import org.ta4j.core.criteria.NumberOfLosingPositionsCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Average gross loss criterion (includes trading costs).
+ * Average net loss criterion.
+ *
+ * <p>
+ * Uses {@link LossCriterion} with trading costs included, meaning costs are
+ * subtracted from each losing position before averaging.
  */
 public class AverageLossCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
@@ -31,7 +31,11 @@ import org.ta4j.core.criteria.NumberOfWinningPositionsCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Average gross profit criterion (includes trading costs).
+ * Average net profit criterion.
+ *
+ * <p>
+ * Uses {@link ProfitCriterion} with trading costs included, meaning costs are
+ * subtracted from each winning position before averaging.
  */
 public class AverageProfitCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/LossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/LossCriterion.java
@@ -30,7 +30,14 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Loss criterion with trading costs (= Gross loss) or without ( = Net loss).
+ * Loss criterion which can either compute the <em>net</em> or the <em>gross</em>
+ * loss.
+ *
+ * <p>
+ * If {@code excludeCosts} is {@code false} (the default), trading costs are
+ * deducted from each position so the value represents the net loss. If
+ * {@code excludeCosts} is {@code true}, trading costs are ignored and the gross
+ * loss is returned.
  *
  * <p>
  * The loss of the provided {@link Position position(s)} over the provided
@@ -41,7 +48,8 @@ public class LossCriterion extends AbstractAnalysisCriterion {
     private final boolean excludeCosts;
 
     /**
-     * Constructor for GrossLoss (includes trading costs).
+     * Constructor creating a criterion that subtracts trading costs from the
+     * result (net loss).
      */
     public LossCriterion() {
         this(false);
@@ -50,7 +58,8 @@ public class LossCriterion extends AbstractAnalysisCriterion {
     /**
      * Constructor.
      *
-     * @param excludeCosts set to true to exclude trading costs
+     * @param excludeCosts set to {@code true} to ignore trading costs and compute
+     *                     the gross loss
      */
     public LossCriterion(boolean excludeCosts) {
         this.excludeCosts = excludeCosts;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitCriterion.java
@@ -30,8 +30,14 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Profit criterion with trading costs (= Gross profit) or without ( = Net
- * profit).
+ * Profit criterion which can either compute the <em>net</em> or the <em>gross</em>
+ * profit.
+ *
+ * <p>
+ * If {@code excludeCosts} is {@code false} (the default), trading costs are
+ * deducted from each position and the resulting value represents the net
+ * profit. If {@code excludeCosts} is {@code true}, the calculation ignores
+ * trading costs and returns the gross profit instead.
  *
  * <p>
  * The profit of the provided {@link Position position(s)} over the provided
@@ -42,7 +48,8 @@ public class ProfitCriterion extends AbstractAnalysisCriterion {
     private final boolean excludeCosts;
 
     /**
-     * Constructor for GrossProfit (includes trading costs).
+     * Constructor creating a criterion that includes trading costs in the
+     * profit calculation, i.e. net profit is returned.
      */
     public ProfitCriterion() {
         this(false);
@@ -51,7 +58,8 @@ public class ProfitCriterion extends AbstractAnalysisCriterion {
     /**
      * Constructor.
      *
-     * @param excludeCosts set to true to exclude trading costs
+     * @param excludeCosts set to {@code true} to ignore trading costs and return
+     *                     gross profit
      */
     public ProfitCriterion(boolean excludeCosts) {
         this.excludeCosts = excludeCosts;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossCriterion.java
@@ -30,10 +30,11 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Net Profit and loss criterion (absolute PnL, includes trading costs).
+ * Net Profit and loss criterion (absolute PnL).
  *
  * <p>
- * The profit or loss over the provided {@link BarSeries series}.
+ * Trading costs are subtracted from each position so the returned value reflects
+ * the net profit or loss over the provided {@link BarSeries series}.
  */
 public class ProfitLossCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
@@ -30,9 +30,13 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Ratio gross profit and loss criterion = Average gross profit (includes
- * trading costs) / Average gross loss (includes trading costs), returned in
- * decimal format.
+ * Profit/Loss ratio criterion.
+ *
+ * <p>
+ * Defined as the average net profit divided by the average net loss. Both
+ * averages include trading costs; that is, costs are subtracted from each
+ * position before computing the mean values. The ratio is returned in decimal
+ * format.
  */
 public class ProfitLossRatioCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -30,8 +30,12 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Return (in percentage) criterion (includes trading costs), returned in
- * decimal format.
+ * Return (in percentage) criterion, returned in decimal format.
+ *
+ * <p>
+ * This criterion uses the gross return of the positions; trading costs are not
+ * deducted from the calculation. It represents the percentage change including
+ * the base value.
  *
  * <p>
  * The return of the provided {@link Position position(s)} over the provided


### PR DESCRIPTION
## Summary
- improve comments in PnL related criterion classes to explicitly describe
  how trading costs are treated

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn: command not found`)*