### PR TITLE
Fix tests for loss-related PnL criteria

### DIFF
--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AbstractPnlCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AbstractPnlCriterionTest.java
@@ -159,7 +159,7 @@ public abstract class AbstractPnlCriterionTest extends AbstractCriterionTest {
         var record = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series), Trade.buyAt(3, series));
 
         AnalysisCriterion criterion = getCriterion();
-        assertNumEquals(10, criterion.calculate(series, record));
+        handleCalculateWithOpenedPosition(criterion.calculate(series, record));
     }
 
     protected abstract void handleCalculateWithProfits(Num result);
@@ -177,4 +177,6 @@ public abstract class AbstractPnlCriterionTest extends AbstractCriterionTest {
     protected abstract void handleBetterThan(AnalysisCriterion criterion);
 
     protected abstract void handleCalculateOneOpenPositionShouldReturnZero();
+
+    protected abstract void handleCalculateWithOpenedPosition(Num result);
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossAverageLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossAverageLossCriterionTest.java
@@ -25,6 +25,7 @@ package org.ta4j.core.criteria.pnl;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -77,5 +78,10 @@ public class GrossAverageLossCriterionTest extends AbstractPnlCriterionTest {
     @Override
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
+    }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(0, result);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossAverageProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossAverageProfitCriterionTest.java
@@ -78,4 +78,9 @@ public class GrossAverageProfitCriterionTest extends AbstractPnlCriterionTest {
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
     }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(10, result);
+    }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossLossCriterionTest.java
@@ -26,6 +26,7 @@ package org.ta4j.core.criteria.pnl;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.ta4j.core.CriterionFactory;
@@ -78,5 +79,10 @@ public class GrossLossCriterionTest extends AbstractPnlCriterionTest {
     @Override
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
+    }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(0, result);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossProfitCriterionTest.java
@@ -79,4 +79,9 @@ public class GrossProfitCriterionTest extends AbstractPnlCriterionTest {
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
     }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(10, result);
+    }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossProfitLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossProfitLossCriterionTest.java
@@ -79,4 +79,9 @@ public class GrossProfitLossCriterionTest extends AbstractPnlCriterionTest {
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
     }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(10, result);
+    }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetAverageLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetAverageLossCriterionTest.java
@@ -25,6 +25,7 @@ package org.ta4j.core.criteria.pnl;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -77,5 +78,10 @@ public class NetAverageLossCriterionTest extends AbstractPnlCriterionTest {
     @Override
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
+    }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(0, result);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetAverageProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetAverageProfitCriterionTest.java
@@ -78,4 +78,9 @@ public class NetAverageProfitCriterionTest extends AbstractPnlCriterionTest {
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
     }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(10, result);
+    }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetLossCriterionTest.java
@@ -26,6 +26,7 @@ package org.ta4j.core.criteria.pnl;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.ta4j.core.CriterionFactory;
@@ -78,5 +79,10 @@ public class NetLossCriterionTest extends AbstractPnlCriterionTest {
     @Override
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
+    }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(0, result);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetProfitCriterionTest.java
@@ -79,4 +79,9 @@ public class NetProfitCriterionTest extends AbstractPnlCriterionTest {
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
     }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(10, result);
+    }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetProfitLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetProfitLossCriterionTest.java
@@ -79,4 +79,9 @@ public class NetProfitLossCriterionTest extends AbstractPnlCriterionTest {
     protected void handleCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFactory, getCriterion(), 0);
     }
+
+    @Override
+    protected void handleCalculateWithOpenedPosition(Num result) {
+        assertNumEquals(10, result);
+    }
 }


### PR DESCRIPTION
## Summary
- adjust open position expectation for loss-based criteria
- provide explicit tests for open positions in loss criteria

## Testing
- `mvn -q -pl ta4j-core test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68404960fe3c832d8ffe5de18e72a007