### PR TITLE
Handle zero drawdown correctly in RoMaD

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -28,7 +28,6 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.pnl.NetReturnCriterion;
-import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 /**
@@ -46,24 +45,28 @@ public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        var maxDrawdown = maxDrawdownCriterion.calculate(series, position);
-        if (maxDrawdown.isZero()) {
-            return NaN.NaN;
-        } else {
-            var totalProfit = netReturnCriterion.calculate(series, position);
-            return totalProfit.dividedBy(maxDrawdown);
+        if (position == null || !position.isClosed()) {
+            return series.numFactory().zero();
         }
+        var maxDrawdown = maxDrawdownCriterion.calculate(series, position);
+        var netReturn = netReturnCriterion.calculate(series, position);
+        if (maxDrawdown.isZero()) {
+            return netReturn;
+        }
+        return netReturn.dividedBy(maxDrawdown);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        var maxDrawdown = maxDrawdownCriterion.calculate(series, tradingRecord);
-        if (maxDrawdown.isZero()) {
-            return NaN.NaN;
-        } else {
-            var totalProfit = netReturnCriterion.calculate(series, tradingRecord);
-            return totalProfit.dividedBy(maxDrawdown);
+        if (tradingRecord.getPositions().isEmpty()) {
+            return series.numFactory().zero();
         }
+        var maxDrawdown = maxDrawdownCriterion.calculate(series, tradingRecord);
+        var netReturn = netReturnCriterion.calculate(series, tradingRecord);
+        if (maxDrawdown.isZero()) {
+            return netReturn;
+        }
+        return netReturn.dividedBy(maxDrawdown);
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
@@ -35,7 +35,6 @@ import org.ta4j.core.Position;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
-import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
 
@@ -72,13 +71,13 @@ public class ReturnOverMaxDrawdownCriterionTest extends AbstractCriterionTest {
         var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 6, 8, 20, 3).build();
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
                 Trade.buyAt(2, series), Trade.sellAt(5, series));
-        assertTrue(rrc.calculate(series, tradingRecord).isNaN());
+        assertNumEquals(40d / 3d, rrc.calculate(series, tradingRecord));
     }
 
     @Test
     public void rewardRiskRatioCriterionWithNoPositions() {
         var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 6, 8, 20, 3).build();
-        assertTrue(rrc.calculate(series, new BaseTradingRecord()).isNaN());
+        assertNumEquals(0d, rrc.calculate(series, new BaseTradingRecord()));
     }
 
     @Test
@@ -109,7 +108,7 @@ public class ReturnOverMaxDrawdownCriterionTest extends AbstractCriterionTest {
 
         final Num result = rrc.calculate(series, tradingRecord);
 
-        assertNumEquals(NaN.NaN, result);
+        assertNumEquals(105d / 100d * 100d / 95d, result);
     }
 
     @Test
@@ -121,6 +120,17 @@ public class ReturnOverMaxDrawdownCriterionTest extends AbstractCriterionTest {
 
         final Num result = rrc.calculate(series, position);
 
-        assertNumEquals(NaN.NaN, result);
+        assertNumEquals(105d / 100d, result);
+    }
+
+    @Test
+    public void testOpenPositionReturnsZero() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 105, 95, 100)
+                .build();
+        Position position = new Position();
+        position.operate(0, series.getBar(0).getClosePrice(), series.numOf(1));
+
+        assertNumEquals(0d, rrc.calculate(series, position));
     }
 }


### PR DESCRIPTION
## Summary
- return 0 for strategies without trades
- return 0 for unclosed positions
- return net return when max drawdown is zero
- add unit test for open position

## Testing
- `mvn -q -pl ta4j-core test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8155bd1c832d849aa9978cbd6d75