### PR TITLE
test: cover commission and trade criteria

### DIFF
--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/InPositionPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/InPositionPercentageCriterionTest.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.DecimalNumFactory;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class InPositionPercentageCriterionTest extends AbstractCriterionTest {
+
+    public InPositionPercentageCriterionTest(NumFactory numFactory) {
+        super(params -> new InPositionPercentageCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsPercentageForClosedPosition() {
+        var series = buildSeries(5, Duration.ofHours(1));
+        var amount = numFactory.one();
+        Trade entry = Trade.buyAt(1, series.getBar(1).getClosePrice(), amount);
+        Trade exit = Trade.sellAt(3, series.getBar(3).getClosePrice(), amount);
+        Position position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        Num result = criterion.calculate(series, position);
+
+        long totalDuration = totalDuration(series);
+        long positionDuration = positionDuration(series, entry.getIndex(), exit.getIndex());
+        double expectedPercentage = totalDuration == 0 ? 0 : (double) positionDuration / totalDuration * 100;
+        var expected = DecimalNumFactory.getInstance().numOf(expectedPercentage);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsPercentageForOpenPosition() {
+        var series = buildSeries(5, Duration.ofHours(1));
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+        record.enter(3, series.getBar(3).getClosePrice(), amount);
+        Position openPosition = record.getCurrentPosition();
+
+        var criterion = getCriterion();
+        Num result = criterion.calculate(series, openPosition);
+
+        long totalDuration = totalDuration(series);
+        long positionDuration = positionDuration(series, openPosition.getEntry().getIndex(), series.getEndIndex());
+        double expectedPercentage = totalDuration == 0 ? 0 : (double) positionDuration / totalDuration * 100;
+        var expected = DecimalNumFactory.getInstance().numOf(expectedPercentage);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateAggregatesDurationsAcrossRecord() {
+        var series = buildSeries(5, Duration.ofHours(1));
+        var record = new BaseTradingRecord();
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(3, series.getBar(3).getClosePrice(), amount);
+        record.exit(4, series.getBar(4).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        Num result = criterion.calculate(series, record);
+
+        long totalDuration = totalDuration(series);
+        long accumulatedDuration = record.getPositions().stream()
+                .mapToLong(p -> positionDuration(series, p.getEntry().getIndex(), p.isClosed() ? p.getExit().getIndex()
+                        : series.getEndIndex()))
+                .sum();
+        double expectedPercentage = totalDuration == 0 ? 0 : (double) accumulatedDuration / totalDuration * 100;
+        var expected = numFactory.numOf(expectedPercentage);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenRecordHasNoPositions() {
+        var series = buildSeries(4, Duration.ofHours(1));
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, new BaseTradingRecord()));
+    }
+
+    @Test
+    public void betterThanPrefersSmallerPercentage() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(20), numFactory.numOf(40)));
+        assertFalse(criterion.betterThan(numFactory.numOf(60), numFactory.numOf(30)));
+    }
+
+    private BarSeries buildSeries(int barCount, Duration barDuration) {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        for (int i = 0; i < barCount; i++) {
+            series.barBuilder()
+                    .timePeriod(barDuration)
+                    .closePrice(numFactory.zero())
+                    .openPrice(numFactory.zero())
+                    .highPrice(numFactory.zero())
+                    .lowPrice(numFactory.zero())
+                    .volume(numFactory.zero())
+                    .trades(0)
+                    .add();
+        }
+        return series;
+    }
+
+    private static long totalDuration(BarSeries series) {
+        return ChronoUnit.NANOS.between(series.getFirstBar().getBeginTime(), series.getLastBar().getEndTime());
+    }
+
+    private static long positionDuration(BarSeries series, int entryIndex, int exitIndex) {
+        var entryStart = series.getBar(entryIndex).getBeginTime();
+        var exitEnd = series.getBar(exitIndex).getEndTime();
+        return ChronoUnit.NANOS.between(entryStart, exitEnd);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/commission/CommissionCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/commission/CommissionCriterionTest.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.commission;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.analysis.cost.FixedTransactionCostModel;
+import org.ta4j.core.analysis.cost.ZeroCostModel;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class CommissionCriterionTest extends AbstractCriterionTest {
+
+    public CommissionCriterionTest(NumFactory numFactory) {
+        super(params -> new CommissionCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsZeroForOpenPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 110, 120).build();
+        var costModel = new FixedTransactionCostModel(1.5);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        var openPosition = record.getCurrentPosition();
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, openPosition));
+    }
+
+    @Test
+    public void calculateReturnsCommissionForClosedPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120).build();
+        var costModel = new FixedTransactionCostModel(2.0);
+        var amount = numFactory.one();
+
+        Trade entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount, costModel);
+        Trade exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount, costModel);
+        Position position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        Num result = criterion.calculate(series, position);
+
+        assertNumEquals(costModel.calculate(position), result);
+    }
+
+    @Test
+    public void calculateSumsClosedPositionsFromRecord() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 110, 120, 130, 140).build();
+        var costModel = new FixedTransactionCostModel(1.0);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        record.exit(3, series.getBar(3).getClosePrice(), amount);
+
+        record.enter(4, series.getBar(4).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        Num result = criterion.calculate(series, record);
+
+        Num expected = record.getPositions().stream()
+                .filter(Position::isClosed)
+                .map(p -> record.getTransactionCostModel().calculate(p))
+                .reduce(numFactory.zero(), Num::plus);
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void betterThanPrefersLowerCommission() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.one(), numFactory.two()));
+        assertFalse(criterion.betterThan(numFactory.two(), numFactory.one()));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/commission/CommissionImpactPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/commission/CommissionImpactPercentageCriterionTest.java
@@ -1,0 +1,138 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.commission;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.analysis.cost.FixedTransactionCostModel;
+import org.ta4j.core.analysis.cost.ZeroCostModel;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class CommissionImpactPercentageCriterionTest extends AbstractCriterionTest {
+
+    public CommissionImpactPercentageCriterionTest(NumFactory numFactory) {
+        super(params -> new CommissionImpactPercentageCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsPercentageForPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120).build();
+        var costModel = new FixedTransactionCostModel(1.5);
+        var amount = numFactory.one();
+
+        Trade entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount, costModel);
+        Trade exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount, costModel);
+        Position position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        Num result = criterion.calculate(series, position);
+
+        Num gross = position.getGrossProfit().abs();
+        Num commission = position.getPositionCost().abs();
+        Num expected = commission.dividedBy(gross).multipliedBy(numFactory.hundred());
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenGrossIsZero() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 100).build();
+        var costModel = new FixedTransactionCostModel(2.0);
+        var amount = numFactory.one();
+
+        Trade entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount, costModel);
+        Trade exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount, costModel);
+        Position position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateUsesAggregatedProfitAndCommissionFromRecord() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120, 90, 80, 70).build();
+        var costModel = new FixedTransactionCostModel(1.0);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        record.exit(3, series.getBar(3).getClosePrice(), amount);
+
+        record.enter(4, series.getBar(4).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        Num result = criterion.calculate(series, record);
+
+        var zero = numFactory.zero();
+        Num totalGross = record.getPositions().stream()
+                .filter(Position::isClosed)
+                .map(Position::getGrossProfit)
+                .reduce(zero, Num::plus)
+                .abs();
+        Num totalCommission = record.getPositions().stream()
+                .filter(Position::isClosed)
+                .map(p -> record.getTransactionCostModel().calculate(p).abs())
+                .reduce(zero, Num::plus);
+        Num expected = totalGross.isZero() ? zero : totalCommission.dividedBy(totalGross).multipliedBy(numFactory.hundred());
+
+        assertNumEquals(expected, result);
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenRecordGrossIsZero() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120, 130, 110).build();
+        var costModel = new FixedTransactionCostModel(0.5);
+        var record = new BaseTradingRecord(TradeType.BUY, costModel, new ZeroCostModel());
+        var amount = numFactory.one();
+
+        record.enter(0, series.getBar(0).getClosePrice(), amount);
+        record.exit(1, series.getBar(1).getClosePrice(), amount);
+
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        record.exit(3, series.getBar(3).getClosePrice(), amount);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersLowerImpact() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.one(), numFactory.two()));
+        assertFalse(criterion.betterThan(numFactory.two(), numFactory.one()));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxConsecutiveLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxConsecutiveLossCriterionTest.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class MaxConsecutiveLossCriterionTest extends AbstractCriterionTest {
+
+    public MaxConsecutiveLossCriterionTest(NumFactory numFactory) {
+        super(params -> new MaxConsecutiveLossCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsLossForLosingPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 90).build();
+        var amount = numFactory.one();
+        Trade entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        Trade exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(-10), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateReturnsZeroForWinningOrOpenPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 110, 120).build();
+        var amount = numFactory.one();
+        Trade winEntry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        Trade winExit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var winningPosition = new Position(winEntry, winExit);
+
+        var record = new BaseTradingRecord();
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        var openPosition = record.getCurrentPosition();
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, winningPosition));
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, openPosition));
+    }
+
+    @Test
+    public void calculateIdentifiesWorstConsecutiveLoss() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+                .build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(10), amount);
+        record.exit(1, numFactory.numOf(9), amount); // -1
+
+        record.enter(2, numFactory.numOf(11), amount);
+        record.exit(3, numFactory.numOf(9), amount); // -2 (streak total -3)
+
+        record.enter(4, numFactory.numOf(8), amount);
+        record.exit(5, numFactory.numOf(11), amount); // +3 resets streak
+
+        record.enter(6, numFactory.numOf(7), amount);
+        record.exit(7, numFactory.numOf(3), amount); // -4
+
+        record.enter(8, numFactory.numOf(6), amount);
+        record.exit(9, numFactory.numOf(5), amount); // -1 -> cumulative -5
+
+        record.enter(10, numFactory.numOf(5), amount);
+        record.exit(11, numFactory.numOf(3), amount); // -2 -> cumulative -7
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(-7), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersSmallerLoss() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(-2), numFactory.numOf(-5)));
+        assertFalse(criterion.betterThan(numFactory.numOf(-6), numFactory.numOf(-3)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxConsecutiveProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxConsecutiveProfitCriterionTest.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class MaxConsecutiveProfitCriterionTest extends AbstractCriterionTest {
+
+    public MaxConsecutiveProfitCriterionTest(NumFactory numFactory) {
+        super(params -> new MaxConsecutiveProfitCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsProfitForWinningPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 120).build();
+        var amount = numFactory.one();
+        Trade entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        Trade exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(20), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateReturnsZeroForLosingOrOpenPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 90, 80).build();
+        var amount = numFactory.one();
+        Trade lossEntry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        Trade lossExit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var losingPosition = new Position(lossEntry, lossExit);
+
+        var record = new BaseTradingRecord();
+        record.enter(2, series.getBar(2).getClosePrice(), amount);
+        var openPosition = record.getCurrentPosition();
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, losingPosition));
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, openPosition));
+    }
+
+    @Test
+    public void calculateIdentifiesBestConsecutiveProfit() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+                .build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(10), amount);
+        record.exit(1, numFactory.numOf(12), amount); // +2
+
+        record.enter(2, numFactory.numOf(8), amount);
+        record.exit(3, numFactory.numOf(10), amount); // +2 -> streak 4
+
+        record.enter(4, numFactory.numOf(9), amount);
+        record.exit(5, numFactory.numOf(7), amount); // -2 resets
+
+        record.enter(6, numFactory.numOf(6), amount);
+        record.exit(7, numFactory.numOf(9), amount); // +3
+
+        record.enter(8, numFactory.numOf(5), amount);
+        record.exit(9, numFactory.numOf(8), amount); // +3 -> streak 6
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(6), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersGreaterProfit() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(5), numFactory.numOf(3)));
+        assertFalse(criterion.betterThan(numFactory.numOf(1), numFactory.numOf(4)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxPositionNetLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxPositionNetLossCriterionTest.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class MaxPositionNetLossCriterionTest extends AbstractCriterionTest {
+
+    public MaxPositionNetLossCriterionTest(NumFactory numFactory) {
+        super(params -> new MaxPositionNetLossCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsNetProfitOfPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 90).build();
+        var amount = numFactory.one();
+        Trade entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        Trade exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(-10), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateFindsMostNegativeClosedPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(1, 2, 3, 4, 5, 6)
+                .build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(10), amount);
+        record.exit(1, numFactory.numOf(8), amount); // -2
+
+        record.enter(2, numFactory.numOf(6), amount);
+        record.exit(3, numFactory.numOf(11), amount); // +5
+
+        record.enter(4, numFactory.numOf(7), amount);
+        record.exit(5, numFactory.numOf(6), amount); // -1
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(-2), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenNoLosses() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 4).build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(5), amount);
+        record.exit(1, numFactory.numOf(7), amount); // +2
+
+        record.enter(2, numFactory.numOf(6), amount);
+        record.exit(3, numFactory.numOf(9), amount); // +3
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersSmallerLoss() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(-1), numFactory.numOf(-3)));
+        assertFalse(criterion.betterThan(numFactory.numOf(-4), numFactory.numOf(-2)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxPositionNetProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/MaxPositionNetProfitCriterionTest.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+public class MaxPositionNetProfitCriterionTest extends AbstractCriterionTest {
+
+    public MaxPositionNetProfitCriterionTest(NumFactory numFactory) {
+        super(params -> new MaxPositionNetProfitCriterion(), numFactory);
+    }
+
+    @Test
+    public void calculateReturnsNetProfitOfPosition() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 130).build();
+        var amount = numFactory.one();
+        Trade entry = Trade.buyAt(0, series.getBar(0).getClosePrice(), amount);
+        Trade exit = Trade.sellAt(1, series.getBar(1).getClosePrice(), amount);
+        var position = new Position(entry, exit);
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(30), criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculateFindsLargestClosedProfit() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(1, 2, 3, 4, 5, 6)
+                .build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(5), amount);
+        record.exit(1, numFactory.numOf(7), amount); // +2
+
+        record.enter(2, numFactory.numOf(6), amount);
+        record.exit(3, numFactory.numOf(11), amount); // +5
+
+        record.enter(4, numFactory.numOf(8), amount);
+        record.exit(5, numFactory.numOf(6), amount); // -2
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.numOf(5), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void calculateReturnsZeroWhenNoProfits() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 4).build();
+        var amount = numFactory.one();
+        var record = new BaseTradingRecord();
+
+        record.enter(0, numFactory.numOf(10), amount);
+        record.exit(1, numFactory.numOf(7), amount); // -3
+
+        record.enter(2, numFactory.numOf(9), amount);
+        record.exit(3, numFactory.numOf(6), amount); // -3
+
+        var criterion = getCriterion();
+        assertNumEquals(numFactory.zero(), criterion.calculate(series, record));
+    }
+
+    @Test
+    public void betterThanPrefersGreaterProfit() {
+        var criterion = getCriterion();
+        assertTrue(criterion.betterThan(numFactory.numOf(4), numFactory.numOf(2)));
+        assertFalse(criterion.betterThan(numFactory.numOf(1), numFactory.numOf(3)));
+    }
+}


### PR DESCRIPTION
## Summary
- add comprehensive tests for commission and commission impact criteria
- exercise max consecutive pnl and per-position net pnl criteria, including open positions
- validate in-position percentage calculations for closed, open, and aggregated records

## Testing
- mvn -pl ta4j-core test *(fails: cannot download org.apache.maven.plugins:maven-source-plugin:3.3.1 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc553b0218832d9cc36463bc426969